### PR TITLE
Reimplement ClientConfig with pydantic

### DIFF
--- a/jumpstarter/config/__init__.py
+++ b/jumpstarter/config/__init__.py
@@ -1,4 +1,8 @@
-from .client import ClientConfig, ClientConfigDrivers
+from .client import (
+    ClientConfigV1Alpha1,
+    ClientConfigV1Alpha1Client,
+    ClientConfigV1Alpha1Drivers,
+)
 from .common import CONFIG_API_VERSION, CONFIG_PATH
 from .env import JMP_CLIENT_CONFIG, JMP_DRIVERS_ALLOW, JMP_ENDPOINT, JMP_TOKEN
 from .user import UserConfig
@@ -12,6 +16,7 @@ __all__ = [
     "JMP_DRIVERS_ALLOW",
     "JMP_DRIVERS_ALLOW_UNSAFE",
     "UserConfig",
-    "ClientConfig",
-    "ClientConfigDrivers",
+    "ClientConfigV1Alpha1",
+    "ClientConfigV1Alpha1Client",
+    "ClientConfigV1Alpha1Drivers",
 ]

--- a/jumpstarter/config/client.py
+++ b/jumpstarter/config/client.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 from typing import ClassVar, Literal, Optional, Self
 
 import yaml
@@ -31,7 +32,7 @@ class ClientConfigV1Alpha1Client(BaseModel):
 
 
 class ClientConfigV1Alpha1(BaseModel):
-    CLIENT_CONFIGS_PATH: ClassVar[str] = CONFIG_PATH / "clients"
+    CLIENT_CONFIGS_PATH: ClassVar[Path] = CONFIG_PATH / "clients"
 
     name: str = Field(default="default", exclude=True)
     path: str | None = Field(default=None, exclude=True)
@@ -74,10 +75,10 @@ class ClientConfigV1Alpha1(BaseModel):
         )
 
     @classmethod
-    def _get_path(cls, name: str) -> str:
+    def _get_path(cls, name: str) -> Path:
         """Get the regular path of a client config given a name."""
 
-        return f"{cls.CLIENT_CONFIGS_PATH}/{name}.yaml"
+        return cls.CLIENT_CONFIGS_PATH / f"{name}.yaml"
 
     @classmethod
     def load(cls, name: str) -> Self:
@@ -115,7 +116,7 @@ class ClientConfigV1Alpha1(BaseModel):
         files = filter(lambda x: x.endswith(".yaml"), results)
 
         def make_config(file: str):
-            path = f"{cls.CLIENT_CONFIGS_PATH}/{file}"
+            path = cls.CLIENT_CONFIGS_PATH / file
             return cls.from_file(path)
 
         return list(map(make_config, files))

--- a/jumpstarter/config/common.py
+++ b/jumpstarter/config/common.py
@@ -1,2 +1,4 @@
+from pathlib import Path
+
 CONFIG_API_VERSION = "jumpstarter.dev/v1alpha1"
-CONFIG_PATH = "~/.config/jumpstarter"
+CONFIG_PATH = Path.home() / ".config" / "jumpstarter"

--- a/jumpstarter/config/user.py
+++ b/jumpstarter/config/user.py
@@ -4,7 +4,7 @@ from typing import Optional, Self
 
 import yaml
 
-from .client import ClientConfig
+from .client import ClientConfigV1Alpha1
 from .common import CONFIG_API_VERSION, CONFIG_PATH
 
 
@@ -14,11 +14,11 @@ class UserConfig:
 
     # The user config path e.g. ~/.config/jumpstarter
     BASE_CONFIG_PATH = CONFIG_PATH
-    USER_CONFIG_PATH = os.path.expanduser(f"{BASE_CONFIG_PATH}/config.yaml")
+    USER_CONFIG_PATH = CONFIG_PATH / "config.yaml"
 
     CONFIG_KIND = "UserConfig"
 
-    current_client: Optional[ClientConfig]
+    current_client: Optional[ClientConfigV1Alpha1]
     """The currently loaded client configuration."""
 
     def exists() -> bool:
@@ -48,7 +48,7 @@ class UserConfig:
             current_client = None
 
             if current_client_name is not None and current_client_name != "":
-                current_client = ClientConfig.load(current_client_name)
+                current_client = ClientConfigV1Alpha1.load(current_client_name)
 
             return UserConfig(current_client=current_client)
 
@@ -77,7 +77,7 @@ class UserConfig:
     def use_client(self, name: Optional[str]):
         """Updates the current client and saves the user config."""
         if name is not None:
-            self.current_client = ClientConfig.load(name)
+            self.current_client = ClientConfigV1Alpha1.load(name)
         else:
             self.current_client = None
         UserConfig.save(self)

--- a/tests/test_client_config.py
+++ b/tests/test_client_config.py
@@ -1,5 +1,6 @@
 import os
 import tempfile
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -16,7 +17,7 @@ from jumpstarter.config.env import JMP_DRIVERS_ALLOW, JMP_ENDPOINT, JMP_TOKEN
 
 def test_client_ensure_exists_makes_dir(monkeypatch):
     with tempfile.TemporaryDirectory() as d:
-        monkeypatch.setattr(ClientConfigV1Alpha1, "CLIENT_CONFIGS_PATH", f"{d}/clients")
+        monkeypatch.setattr(ClientConfigV1Alpha1, "CLIENT_CONFIGS_PATH", Path(d) / "clients")
         ClientConfigV1Alpha1.ensure_exists()
         assert os.path.exists(ClientConfigV1Alpha1.CLIENT_CONFIGS_PATH)
 
@@ -313,27 +314,26 @@ client:
     - jumpstarter.drivers.*
     - vendorpackage.*
 """
-    d = tempfile.TemporaryDirectory()
-    with open(f"{d.name}/testclient.yaml", "w") as f:
-        f.write(CLIENT_CONFIG)
-        f.close()
+    with tempfile.TemporaryDirectory() as d:
+        with open(Path(d) / "testclient.yaml", "w") as f:
+            f.write(CLIENT_CONFIG)
+            f.close()
 
-    monkeypatch.setattr(ClientConfigV1Alpha1, "CLIENT_CONFIGS_PATH", d.name)
-    configs = ClientConfigV1Alpha1.list()
-    assert len(configs) == 1
-    assert configs[0].name == "testclient"
-    d.cleanup()
+        monkeypatch.setattr(ClientConfigV1Alpha1, "CLIENT_CONFIGS_PATH", Path(d))
+        configs = ClientConfigV1Alpha1.list()
+        assert len(configs) == 1
+        assert configs[0].name == "testclient"
 
 
 def test_client_config_list_none(monkeypatch):
     with tempfile.TemporaryDirectory() as d:
-        monkeypatch.setattr(ClientConfigV1Alpha1, "CLIENT_CONFIGS_PATH", d)
+        monkeypatch.setattr(ClientConfigV1Alpha1, "CLIENT_CONFIGS_PATH", Path(d))
         configs = ClientConfigV1Alpha1.list()
         assert len(configs) == 0
 
 
 def test_client_config_list_not_found_returns_empty(monkeypatch):
-    monkeypatch.setattr(ClientConfigV1Alpha1, "CLIENT_CONFIGS_PATH", "/homeless-shelter")
+    monkeypatch.setattr(ClientConfigV1Alpha1, "CLIENT_CONFIGS_PATH", Path("/homeless-shelter"))
     configs = ClientConfigV1Alpha1.list()
     assert len(configs) == 0
 

--- a/tests/test_user_config.py
+++ b/tests/test_user_config.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 
 import pytest
 
-from jumpstarter.config import ClientConfig, ClientConfigDrivers, UserConfig
+from jumpstarter.config import ClientConfigV1Alpha1, ClientConfigV1Alpha1Client, ClientConfigV1Alpha1Drivers, UserConfig
 
 
 def test_user_config_exists(monkeypatch):
@@ -23,10 +23,13 @@ config:
   current-client: testclient
 """
     with patch.object(
-        ClientConfig,
+        ClientConfigV1Alpha1,
         "load",
-        return_value=ClientConfig(
-            name="testclient", endpoint="abc", token="123", drivers=ClientConfigDrivers(allow=[], unsafe=False)
+        return_value=ClientConfigV1Alpha1(
+            name="testclient",
+            client=ClientConfigV1Alpha1Client(
+                endpoint="abc", token="123", drivers=ClientConfigV1Alpha1Drivers(allow=[], unsafe=False)
+            ),
         ),
     ) as mock_load:
         with tempfile.NamedTemporaryFile(mode="w", delete=False) as f:
@@ -51,10 +54,13 @@ kind: UserConfig
 config: {}
 """
     with patch.object(
-        ClientConfig,
+        ClientConfigV1Alpha1,
         "load",
-        return_value=ClientConfig(
-            name="testclient", endpoint="abc", token="123", drivers=ClientConfigDrivers(allow=[], unsafe=False)
+        return_value=ClientConfigV1Alpha1(
+            name="testclient",
+            client=ClientConfigV1Alpha1Client(
+                endpoint="abc", token="123", drivers=ClientConfigV1Alpha1Drivers(allow=[], unsafe=False)
+            ),
         ),
     ) as mock_load:
         with tempfile.NamedTemporaryFile(mode="w", delete=False) as f:
@@ -74,10 +80,13 @@ config:
     current-client: ""
 """
     with patch.object(
-        ClientConfig,
+        ClientConfigV1Alpha1,
         "load",
-        return_value=ClientConfig(
-            name="testclient", endpoint="abc", token="123", drivers=ClientConfigDrivers(allow=[], unsafe=False)
+        return_value=ClientConfigV1Alpha1(
+            name="testclient",
+            client=ClientConfigV1Alpha1Client(
+                endpoint="abc", token="123", drivers=ClientConfigV1Alpha1Drivers(allow=[], unsafe=False)
+            ),
         ),
     ) as mock_load:
         with tempfile.NamedTemporaryFile(mode="w", delete=False) as f:
@@ -168,8 +177,11 @@ config:
     with tempfile.NamedTemporaryFile(mode="w", delete=False) as f:
         monkeypatch.setattr(UserConfig, "USER_CONFIG_PATH", f.name)
         config = UserConfig(
-            current_client=ClientConfig(
-                name="testclient", endpoint="abc", token="123", drivers=ClientConfigDrivers(allow=[], unsafe=False)
+            current_client=ClientConfigV1Alpha1(
+                name="testclient",
+                client=ClientConfigV1Alpha1Client(
+                    endpoint="abc", token="123", drivers=ClientConfigV1Alpha1Drivers(allow=[], unsafe=False)
+                ),
             )
         )
         UserConfig.save(config)
@@ -202,17 +214,23 @@ config:
   current-client: testclient
 """
     with patch.object(
-        ClientConfig,
+        ClientConfigV1Alpha1,
         "load",
-        return_value=ClientConfig(
-            name="testclient", endpoint="abc", token="123", drivers=ClientConfigDrivers(allow=[], unsafe=False)
+        return_value=ClientConfigV1Alpha1(
+            name="testclient",
+            client=ClientConfigV1Alpha1Client(
+                endpoint="abc", token="123", drivers=ClientConfigV1Alpha1Drivers(allow=[], unsafe=False)
+            ),
         ),
     ) as mock_load:
         with tempfile.NamedTemporaryFile(mode="w", delete=False) as f:
             monkeypatch.setattr(UserConfig, "USER_CONFIG_PATH", f.name)
             config = UserConfig(
-                current_client=ClientConfig(
-                    name="another", endpoint="abc", token="123", drivers=ClientConfigDrivers(allow=[], unsafe=False)
+                current_client=ClientConfigV1Alpha1(
+                    name="another",
+                    client=ClientConfigV1Alpha1Client(
+                        endpoint="abc", token="123", drivers=ClientConfigV1Alpha1Drivers(allow=[], unsafe=False)
+                    ),
                 )
             )
             config.use_client("testclient")
@@ -233,8 +251,11 @@ config:
     with tempfile.NamedTemporaryFile(mode="w", delete=False) as f:
         monkeypatch.setattr(UserConfig, "USER_CONFIG_PATH", f.name)
         config = UserConfig(
-            current_client=ClientConfig(
-                name="another", endpoint="abc", token="123", drivers=ClientConfigDrivers(allow=[], unsafe=False)
+            current_client=ClientConfigV1Alpha1(
+                name="another",
+                client=ClientConfigV1Alpha1Client(
+                    endpoint="abc", token="123", drivers=ClientConfigV1Alpha1Drivers(allow=[], unsafe=False)
+                ),
             )
         )
         config.use_client(None)


### PR DESCRIPTION
We also need to think about future config version updates.

Proposal:
Support loading old versions, only support writing latest version. When saving old versions, transparently upgrade them to the latest version.